### PR TITLE
Add installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,17 @@ This project imports the [Meshtastic.js library](https://github.com/meshtastic/m
 
 
 ![Gif](images/meshtasticreactv0.5.gif)
+
+## Installation Instructions
+
+1. Connect your radio to your local WiFi network/router (use the python api to set this up: `meshtastic --set wifi_ap_mode false --setstr wifi_ssid mywifissid --setstr wifi_password mywifipsw`
+
+1. Using PlatformIO or `http://meshtastic.local/static` or `http://[IP Displayed on Mestashtic Device]/static` navigate to your radio’s /static page.
+
+1. Delete all files on SPIFFS (SPI Flash File System) using the delete links.
+
+1. Upload the three files attached to the following page https://github.com/crossan007/meshtastic-web/releases/tag/0.1.1 5 ( index.html.gz , app.js.gz and app.css.gz )
+
+1. Navigate to the root URL of your radio.
+
+1. (Optional) If you want to setup softAP mode for the device use the Python API `meshtastic --set wifi_ap_mode true --setstr wifi_ssid mywifissid --setstr wifi_password mywifipsw`


### PR DESCRIPTION
Adding the installation instructions from [here](https://meshtastic.discourse.group/t/want-to-help-alpha-test-this-build-no-new-tests-needed-at-this-time/1862/86) to the README so that it's available from within the repository.