### PR TITLE
CI with GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: meshtastic-web build
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build-and-package:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out repository
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Build project
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          cache: 'yarn'
+      - run: yarn install --ignore-optional
+      - run: yarn lint
+      - run: yarn build
+      - run: yarn package
+    
+      # Upload Artifact
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: meshtastic-web
+          path: build/output


### PR DESCRIPTION
Workflow to build and package the project. Compressed artifacts uploaded to Actions.

`yarn install`, `yarn lint`, `yarn build`, and `yarn package` will always run on every push to the master branch or pull request merge.

An example of an executed GitHub Actions workflow could be found in my fork at https://github.com/osmanovv/meshtastic-web/actions/runs/1131106674. There is also an artifact with project files at the bottom of that page.

Details of this completed job could be found at https://github.com/osmanovv/meshtastic-web/runs/3330266279?check_suite_focus=true

More info about GitHub Actions:
- [GitHub Actions](https://github.com/features/actions),
- [GitHub Actions Docs](https://docs.github.com/en/actions).